### PR TITLE
fix: sanitize column names in Clickhouse schema generation

### DIFF
--- a/src/utils/clickhouse.ts
+++ b/src/utils/clickhouse.ts
@@ -135,7 +135,9 @@ export async function generateDDL(
         ? col.type.replace('Nullable(', '').replace(')', '')
         : col.type;
 
-      return `${col.name} ${type}`;
+      // Sanitize column name to only allow alphanumeric characters and underscores
+      const sanitizedName = col.name.replace(/[^a-zA-Z0-9_]/g, '_');
+      return `${sanitizedName} ${type}`;
     })
     .join(', ');
 


### PR DESCRIPTION
- Added regex validation to ensure column names only contain alphanumeric characters and underscores
- Prevents SQL syntax errors and potential injection vulnerabilities when creating tables
- Automatically replaces invalid characters with underscores